### PR TITLE
switch network (without add) should connect wallet

### DIFF
--- a/src/providers/WalletProvider.tsx
+++ b/src/providers/WalletProvider.tsx
@@ -178,6 +178,7 @@ export const WalletProvider = ({ children }: WalletProviderProps) => {
         }
         try {
             await trySwitchToAlpen();
+            setIsOnAlpenTestnet(true);
         } catch (switchError: any) {
             // Unrecognized chain ID.
             if (switchError.code === 4902) {


### PR DESCRIPTION
This case was not visible in Chrome or Brave. Tested in Firefox.