### PR TITLE
STR-1421 website title should say Alpen faucet

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Strata Faucet</title>
+        <title>Alpen Faucet</title>
         <link rel="icon" type="image/png" href="/favicon.png" />
     </head>
     <body>


### PR DESCRIPTION
Renaming missed the website title.

[STR-1421](https://alpenlabs.atlassian.net/browse/STR-1421)

[STR-1421]: https://alpenlabs.atlassian.net/browse/STR-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ